### PR TITLE
Fix(lib/ChillxExtractor): Unify extraction logic, improve key fetching and subtitle handling

### DIFF
--- a/lib/chillx-extractor/src/main/java/eu/kanade/tachiyomi/lib/chillxextractor/ChillxExtractor.kt
+++ b/lib/chillx-extractor/src/main/java/eu/kanade/tachiyomi/lib/chillxextractor/ChillxExtractor.kt
@@ -12,24 +12,19 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import okhttp3.Headers
 import okhttp3.OkHttpClient
-import org.jsoup.Jsoup
 import uy.kohesive.injekt.injectLazy
 
 class ChillxExtractor(private val client: OkHttpClient, private val headers: Headers) {
     private val json: Json by injectLazy()
-
     private val playlistUtils by lazy { PlaylistUtils(client, headers) }
 
     companion object {
-        private val REGEX_MASTER_JS by lazy { Regex("""JScript[\w+]?\s*=\s*'([^']+)""") }
-        private val REGEX_EVAL_KEY by lazy { Regex("""eval\(\S+\("(\S+)",\d+,"(\S+)",(\d+),(\d+),""") }
+        private val REGEX_MASTER_JS by lazy { Regex("""\s*=\s*'([^']+)""") }
         private val REGEX_SOURCES by lazy { Regex("""sources:\s*\[\{"file":"([^"]+)""") }
         private val REGEX_FILE by lazy { Regex("""file: ?"([^"]+)"""") }
         private val REGEX_SOURCE by lazy { Regex("""source = ?"([^"]+)"""") }
-
-        // matches "[language]https://...,"
-        private val REGEX_SUBS by lazy { Regex("""\[(.*?)\](.*?)"?\,""") }
-        private const val KEY_SOURCE = "https://rowdy-avocado.github.io/multi-keys/"
+        private val REGEX_SUBS by lazy { Regex("""\[(.*?)\](https?://[^\s,]+)""") }
+        private const val KEY_SOURCE = "https://raw.githubusercontent.com/Rowdy-Avocado/multi-keys/keys/index.html"
     }
 
     fun videoFromUrl(url: String, referer: String, prefix: String = "Chillx - "): List<Video> {
@@ -42,7 +37,7 @@ class ChillxExtractor(private val client: OkHttpClient, private val headers: Hea
 
         val master = REGEX_MASTER_JS.find(body)?.groupValues?.get(1) ?: return emptyList()
         val aesJson = json.decodeFromString<CryptoInfo>(master)
-        val key = fetchKey()
+        val key = fetchKey() ?: throw ErrorLoadingException("Unable to get key")
         val decryptedScript = decryptWithSalt(aesJson.ciphertext, aesJson.salt, key)
             .replace("\\n", "\n")
             .replace("\\", "")
@@ -52,30 +47,11 @@ class ChillxExtractor(private val client: OkHttpClient, private val headers: Hea
             ?: REGEX_SOURCE.find(decryptedScript)?.groupValues?.get(1)
             ?: return emptyList()
 
-        val subtitleList = buildList<Track> {
-            body.takeIf { it.contains("<track kind=\"captions\"") }
-                ?.let(Jsoup::parse)
-                ?.select("track[kind=captions]")
-                ?.forEach {
-                    add(Track(it.attr("src"), it.attr("label")))
-                }
-
-            decryptedScript.takeIf { it.contains("subtitle:") }
-                ?.substringAfter("subtitle: ")
-                ?.substringBefore("\n")
-                ?.let(REGEX_SUBS::findAll)
-                ?.forEach { add(Track(it.groupValues[2], it.groupValues[1])) }
-
-            decryptedScript.takeIf { it.contains("tracks:") }
-                ?.substringAfter("tracks: ")
-                ?.substringBefore("\n")
-                ?.also {
-                    runCatching {
-                        json.decodeFromString<List<TrackDto>>(it)
-                            .filter { it.kind == "captions" }
-                            .forEach { add(Track(it.file, it.label)) }
-                    }
-                }
+        val subtitleList = buildList {
+            val subtitles = REGEX_SUBS.findAll(decryptedScript)
+            subtitles.forEach {
+                add(Track(it.groupValues[2], decodeUnicodeEscape(it.groupValues[1])))
+            }
         }
 
         return playlistUtils.extractFromHls(
@@ -87,25 +63,15 @@ class ChillxExtractor(private val client: OkHttpClient, private val headers: Hea
     }
 
     @OptIn(ExperimentalSerializationApi::class)
-    private fun fetchKey(): String {
-        return client.newCall(GET(KEY_SOURCE)).execute().parseAs<KeysData>().keys.get(0)
+    private fun fetchKey(): String? {
+        return client.newCall(GET(KEY_SOURCE)).execute().parseAs<KeysData>().keys.firstOrNull()
     }
 
-    private fun getKey(body: String): String {
-        val (encrypted, pass, offset, index) = REGEX_EVAL_KEY.find(body)!!.groupValues.drop(1)
-        val decrypted = decryptScript(encrypted, pass, offset.toInt(), index.toInt())
-        return decrypted.substringAfter("'").substringBefore("'")
-    }
-
-    private fun decryptScript(encrypted: String, pass: String, offset: Int, index: Int): String {
-        val trimmedPass = pass.substring(0, index)
-        val bits = encrypted.split(pass[index]).map { item ->
-            trimmedPass.foldIndexed(item) { index, acc, it ->
-                acc.replace(it.toString(), index.toString())
-            }
-        }.filter(String::isNotBlank)
-
-        return bits.joinToString("") { Char(it.toInt(index) - offset).toString() }
+    private fun decodeUnicodeEscape(input: String): String {
+        val regex = Regex("u([0-9a-fA-F]{4})")
+        return regex.replace(input) {
+            it.groupValues[1].toInt(16).toChar().toString()
+        }
     }
 
     @Serializable
@@ -117,15 +83,9 @@ class ChillxExtractor(private val client: OkHttpClient, private val headers: Hea
     )
 
     @Serializable
-    data class TrackDto(
-        val kind: String,
-        val label: String = "",
-        val file: String,
-    )
-
-    @Serializable
     data class KeysData(
         @SerialName("chillx")
         val keys: List<String>
     )
 }
+class ErrorLoadingException(message: String) : Exception(message)


### PR DESCRIPTION

- Unified the `fetchKey` method to ensure a single approach for retrieving the decryption key.
- Corrected `decryptWithSalt` usage to properly decrypt the script.
- Simplified and corrected the handling of subtitle extraction, including Unicode escape decoding.
- Refactored regular expressions to ensure accurate data extraction from the decrypted script.
- Added custom `ErrorLoadingException` for better error management during video loading.